### PR TITLE
Remove problematic import

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"rauth/model"
 	"rauth/query"
 
 	"github.com/spf13/cobra"


### PR DESCRIPTION
This pull request removes an import that was breaking the build; it should make it more streamlined for other developers to contribute in the future, as well as just tidying things up. I'd recommend that if this happens enough times, we add a tool that cleans up imports automatically, but we can cross that bridge when we come to it.