### PR TITLE
Add minor restructuring to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,12 @@
 go.work
 
 # End of https://www.toptal.com/developers/gitignore/api/go
+
+# Common names for executable files
 rauth
+main
+
+# Runtime database
 *.db
 
 # Jetbrains configuration files


### PR DESCRIPTION
Part of an ongoing effort to streamline onboarding for new developers of the project. `go build main.go` default-outputs to `main`, so it's worth adding that to the gitignore. I added some comments while I was in there to keep things tidy.